### PR TITLE
DT-3190 [GitHub] Add support for "GitHub" credentials type in credentials-sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ credentials-sync
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 coverage.txt
+
+# JetBrains products
+.idea

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ my_other_cred:
 ```
 
 ## Supported types of source credentials
-Credentials are defined as JSON, here are the supported types of source credentials with definition examples:
+Credentials are defined as JSON or YAML, here are the supported types of source credentials with definition examples:
  - Secret text
  - Username/Password
  - AWS IAM

--- a/credentials/credentials_github_app.go
+++ b/credentials/credentials_github_app.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 )
 
-// GithubAppCredentials represents credentials composed of a private key, username and passphrase
+// GithubAppCredentials represents credentials composed of an App ID, private key, and owner
 type GithubAppCredentials struct {
 	Base       `mapstructure:",squash"`
 	AppID      int    `mapstructure:"app_id"`

--- a/credentials/credentials_github_app.go
+++ b/credentials/credentials_github_app.go
@@ -1,0 +1,43 @@
+package credentials
+
+import (
+	"fmt"
+)
+
+// GithubAppCredentials represents credentials composed of a private key, username and passphrase
+type GithubAppCredentials struct {
+	Base       `mapstructure:",squash"`
+	AppID      int    `mapstructure:"app_id"`
+	PrivateKey string `mapstructure:"private_key"`
+	Owner      string `mapstructure:"owner"`
+}
+
+// NewGithubAppCredentials instantiates a GithubAppCredentials struct
+func NewGithubAppCredentials() *GithubAppCredentials {
+	cred := &GithubAppCredentials{}
+	cred.CredType = "Github App"
+	return cred
+}
+
+// ToString prints out the content of a GithubAppCredentials struct.
+// showSensitive bool has not effect. It is provided to satisfy the interface.
+func (cred *GithubAppCredentials) ToString(_ bool) string {
+	appIDOwner := fmt.Sprintf("%d", cred.AppID)
+	if len(cred.Owner) > 0 {
+		appIDOwner = fmt.Sprintf("%s(%s)", appIDOwner, cred.Owner)
+	}
+	return fmt.Sprintf("%s - %s", cred.BaseToString(), appIDOwner)
+}
+
+// Validate verifies that the credentials is valid.
+// A GithubAppCredentials must have an app id and a private key.  Owner is optional.
+func (cred *GithubAppCredentials) Validate() error {
+	switch {
+	case cred.AppID == 0:
+		return fmt.Errorf("the credentials with ID %s does not define an app ID", cred.ID)
+	case len(cred.PrivateKey) == 0:
+		return fmt.Errorf("the credentials with ID %s does not define a private key", cred.ID)
+	default:
+		return nil
+	}
+}

--- a/credentials/credentials_github_app.go
+++ b/credentials/credentials_github_app.go
@@ -20,13 +20,17 @@ func NewGithubAppCredentials() *GithubAppCredentials {
 }
 
 // ToString prints out the content of a GithubAppCredentials struct.
-// showSensitive bool has not effect. It is provided to satisfy the interface.
-func (cred *GithubAppCredentials) ToString(_ bool) string {
+func (cred *GithubAppCredentials) ToString(showSensitive bool) string {
+	privateKeyText := "********"
+	if showSensitive {
+		privateKeyText = cred.PrivateKey
+	}
+
 	appIDOwner := fmt.Sprintf("%d", cred.AppID)
 	if len(cred.Owner) > 0 {
 		appIDOwner = fmt.Sprintf("%s(%s)", appIDOwner, cred.Owner)
 	}
-	return fmt.Sprintf("%s - %s", cred.BaseToString(), appIDOwner)
+	return fmt.Sprintf("%s - %s:%s", cred.BaseToString(), appIDOwner, privateKeyText)
 }
 
 // Validate verifies that the credentials is valid.

--- a/credentials/credentials_github_app_test.go
+++ b/credentials/credentials_github_app_test.go
@@ -11,11 +11,14 @@ func TestGithubAppCredentials(t *testing.T) {
 		givenID            string
 		givenAppID         int
 		givenOwner         string
+		givenPrivate       string
 		givenShowSensitive bool
 		expectString       string
 	}{
-		"without owner": {givenID: "test", givenAppID: 1, givenOwner: "", givenShowSensitive: false, expectString: "test -> Type: Github App - 1"},
-		"with owner":    {givenID: "test", givenAppID: 2, givenOwner: "owner", givenShowSensitive: false, expectString: "test -> Type: Github App - 2(owner)"},
+		"without owner":               {givenID: "test", givenAppID: 1, givenOwner: "", givenPrivate: "private", givenShowSensitive: false, expectString: "test -> Type: Github App - 1:********"},
+		"with owner":                  {givenID: "test", givenAppID: 2, givenOwner: "owner", givenPrivate: "private", givenShowSensitive: false, expectString: "test -> Type: Github App - 2(owner):********"},
+		"without owner showSensitive": {givenID: "test", givenAppID: 1, givenOwner: "", givenPrivate: "private", givenShowSensitive: true, expectString: "test -> Type: Github App - 1:private"},
+		"with owner showSensitive":    {givenID: "test", givenAppID: 2, givenOwner: "owner", givenPrivate: "private", givenShowSensitive: true, expectString: "test -> Type: Github App - 2(owner):private"},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -23,6 +26,7 @@ func TestGithubAppCredentials(t *testing.T) {
 			cred.ID = test.givenID
 			cred.AppID = test.givenAppID
 			cred.Owner = test.givenOwner
+			cred.PrivateKey = test.givenPrivate
 			assert.Equal(t, test.expectString, cred.ToString(test.givenShowSensitive))
 		})
 	}

--- a/credentials/credentials_github_app_test.go
+++ b/credentials/credentials_github_app_test.go
@@ -1,0 +1,66 @@
+package credentials
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGithubAppCredentials(t *testing.T) {
+	tests := map[string]struct {
+		givenID            string
+		givenAppID         int
+		givenOwner         string
+		givenShowSensitive bool
+		expectString       string
+	}{
+		"without owner": {givenID: "test", givenAppID: 1, givenOwner: "", givenShowSensitive: false, expectString: "test -> Type: Github App - 1"},
+		"with owner":    {givenID: "test", givenAppID: 2, givenOwner: "owner", givenShowSensitive: false, expectString: "test -> Type: Github App - 2(owner)"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cred := NewGithubAppCredentials()
+			cred.ID = test.givenID
+			cred.AppID = test.givenAppID
+			cred.Owner = test.givenOwner
+			assert.Equal(t, test.expectString, cred.ToString(test.givenShowSensitive))
+		})
+	}
+}
+
+func TestGithubAppCredentialsValidation(t *testing.T) {
+	tests := map[string]struct {
+		givenCred   GithubAppCredentials
+		expectError bool
+	}{
+		"valid": {givenCred: GithubAppCredentials{
+			AppID:      12345,
+			PrivateKey: "private",
+			Owner:      "Me",
+		}, expectError: false},
+		"valid no owner": {givenCred: GithubAppCredentials{
+			AppID:      12345,
+			PrivateKey: "private",
+		}, expectError: false},
+		"missing app id": {givenCred: GithubAppCredentials{
+			PrivateKey: "private",
+		}, expectError: true},
+		"missing private key": {givenCred: GithubAppCredentials{
+			AppID: 12345,
+		}, expectError: true},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cred := NewGithubAppCredentials()
+			cred.AppID = test.givenCred.AppID
+			cred.PrivateKey = test.givenCred.PrivateKey
+			cred.Owner = test.givenCred.Owner
+			err := cred.Validate()
+			if test.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 require (
 	github.com/aws/aws-sdk-go v1.30.7
-	github.com/bndr/gojenkins v0.0.0-00010101000000-000000000000
+	github.com/bndr/gojenkins v1.0.1
 	github.com/golang/mock v1.4.3
 	github.com/hashicorp/go-multierror v1.1.0
 	github.com/mitchellh/mapstructure v1.2.2

--- a/targets/jenkins_test.go
+++ b/targets/jenkins_test.go
@@ -83,3 +83,21 @@ func TestUsernamePasswordToJenkinsCred(t *testing.T) {
 	assert.Equal(t, secret.Username, jenkinsSecret.Username)
 	assert.Equal(t, secret.Password, jenkinsSecret.Password)
 }
+
+func TestGithubAppToJenkinsCred(t *testing.T) {
+	secret := credentials.NewGithubAppCredentials()
+	secret.ID = "test-id"
+	secret.Description = "a test description"
+	secret.Owner = "a-user"
+	secret.PrivateKey = "a-key"
+	secret.AppID = 12345
+
+	jenkinsSecretInterface := toJenkinsCredential(secret)
+
+	jenkinsSecret := jenkinsSecretInterface.(*JenkinsGithubAppCredentials)
+	assert.Equal(t, secret.ID, jenkinsSecret.ID)
+	assert.Equal(t, secret.Description, jenkinsSecret.Description)
+	assert.Equal(t, secret.Owner, jenkinsSecret.Owner)
+	assert.Equal(t, secret.PrivateKey, jenkinsSecret.PrivateKey)
+	assert.Equal(t, secret.AppID, jenkinsSecret.AppID)
+}


### PR DESCRIPTION
Main changes:
* Added new source type "github_app"
* Updated the documentation in the README
* Tested successfully on one of our Jenkins instance: Succesful sync of a github_app credential that appeared correctly in the Jenkins UI.

Other changes:
* Ran go fmt and golint on the codebase
* Fixed warnings reported by the IDE
* (go.mod) Updated gojenkins library to latest released version
* (credentials.go) Better error messages when parsing of config fails
* (credentials_test.go) Added more tests to cover all valid source types