### PR TITLE
Configure dependabot for this project

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,6 @@ updates:
       - dblanchette
       - dlevesque-coveo
       - dotboris
-      - jocgir
       - jonapich
       - pballandras
       - wtrep
@@ -23,7 +22,6 @@ updates:
       - dblanchette
       - dlevesque-coveo
       - dotboris
-      - jocgir
       - jonapich
       - pballandras
       - wtrep

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 20
+    reviewers:
+      - dblanchette
+      - dlevesque-coveo
+      - dotboris
+      - jocgir
+      - jonapich
+      - pballandras
+      - wtrep
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    open-pull-requests-limit: 20
+    schedule:
+      interval: weekly
+    reviewers:
+      - dblanchette
+      - dlevesque-coveo
+      - dotboris
+      - jocgir
+      - jonapich
+      - pballandras
+      - wtrep


### PR DESCRIPTION
This project used to use the `dependabot-preview` which has been shut down and replaced by the github hosted `dependabot`. This change enabled the github hosted `dependabot` and configures it like our other go projects.

This PR effectively replaces #138 which can be closed.